### PR TITLE
Remove odd conditional in run-filter

### DIFF
--- a/lib/run-filter.js
+++ b/lib/run-filter.js
@@ -7,40 +7,36 @@ var resolve = require('resolve');
 
 module.exports = filter;
 function filter(name, str, options, currentDirectory) {
-  if (typeof filter[name] === 'function') {
-    return filter[name](str, options);
-  } else {
-    var tr;
+  var tr;
+  try {
     try {
-      try {
-        tr = require(resolve.sync('jstransformer-' + name, {basedir: currentDirectory || process.cwd()}));
-      } catch (ex) {
-        tr = require('jstransformer-' + name);
-      }
-      tr = jstransformer(tr);
-    } catch (ex) {}
-    if (tr) {
-      // TODO: we may want to add a way for people to separately specify "locals"
-      var result = tr.render(str, options, options).body;
-      if (options && options.minify) {
-        try {
-          switch (tr.outputFormat) {
-            case 'js':
-              result = uglify.minify(result, {fromString: true}).code;
-              break;
-            case 'css':
-              result = new CleanCSS().minify(result).styles;
-              break;
-          }
-        } catch (ex) {
-          // better to fail to minify than output nothing
-        }
-      }
-      return result;
-    } else {
-      var err = new Error('unknown filter ":' + name + '"');
-      err.code = 'UNKNOWN_FILTER';
-      throw err;
+      tr = require(resolve.sync('jstransformer-' + name, {basedir: currentDirectory || process.cwd()}));
+    } catch (ex) {
+      tr = require('jstransformer-' + name);
     }
+    tr = jstransformer(tr);
+  } catch (ex) {}
+  if (tr) {
+    // TODO: we may want to add a way for people to separately specify "locals"
+    var result = tr.render(str, options, options).body;
+    if (options && options.minify) {
+      try {
+        switch (tr.outputFormat) {
+          case 'js':
+            result = uglify.minify(result, {fromString: true}).code;
+            break;
+          case 'css':
+            result = new CleanCSS().minify(result).styles;
+            break;
+        }
+      } catch (ex) {
+        // better to fail to minify than output nothing
+      }
+    }
+    return result;
+  } else {
+    var err = new Error('unknown filter ":' + name + '"');
+    err.code = 'UNKNOWN_FILTER';
+    throw err;
   }
 }


### PR DESCRIPTION
The check doesn't work, and what it's supposed to handle is handled in handle-filter.js.

You might want to review this PR using [whitespace-ignoring mode](?w=1)
