### PR TITLE
Updated ugilify-js to 2.4.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jade-walk": "0.0.2",
     "jstransformer": "0.0.2",
     "resolve": "^1.1.6",
-    "uglify-js": "^2.4.23"
+    "uglify-js": "^2.4.24"
   },
   "devDependencies": {
     "get-repo": "^1.0.0",


### PR DESCRIPTION
The article at https://zyan.scripts.mit.edu/blog/backdooring-js/ explains how one can leverage a bug in UglifyJS 2.4.23 and earlier to introduce security issues that manifest only in minified code.
