### PR TITLE
Adds support for specifying filter options

### DIFF
--- a/lib/handle-filters.js
+++ b/lib/handle-filters.js
@@ -15,13 +15,12 @@ function handleFilters(ast, filters, options) {
       handleNestedFilters(node, filters);
       var text = getBodyAsText(node);
       var attrs = getAttributes(node);
-      options = options[node.name] || {};
-      for (var attr in attrs) {
-        options[attr] = attrs[attr];
+      for (var opt in options) {
+        attrs[opt] = attrs[opt] || options[opt];
       }
-      options.filename = node.filename;
+      attrs.filename = node.filename;
       node.type = 'Text';
-      node.val = filterWithFallback(node, text, options);
+      node.val = filterWithFallback(node, text, attrs);
     } else if (node.type === 'RawInclude' && node.filters.length) {
       var firstFilter = node.filters.shift();
       var attrs = getAttributes(firstFilter);

--- a/lib/handle-filters.js
+++ b/lib/handle-filters.js
@@ -7,16 +7,21 @@ var error = require('pug-error');
 var runFilter = require('./run-filter');
 
 module.exports = handleFilters;
-function handleFilters(ast, filters) {
+function handleFilters(ast, filters, options) {
+  options = options || {}
   walk(ast, function (node) {
     var dir = node.filename ? dirname(node.filename) : null;
     if (node.type === 'Filter') {
       handleNestedFilters(node, filters);
       var text = getBodyAsText(node);
       var attrs = getAttributes(node);
-      attrs.filename = node.filename;
+      options = options[node.name] || {};
+      for (var attr in attrs) {
+        options[attr] = attrs[attr];
+      }
+      options.filename = node.filename;
       node.type = 'Text';
-      node.val = filterWithFallback(node, text, attrs);
+      node.val = filterWithFallback(node, text, options);
     } else if (node.type === 'RawInclude' && node.filters.length) {
       var firstFilter = node.filters.shift();
       var attrs = getAttributes(firstFilter);

--- a/lib/handle-filters.js
+++ b/lib/handle-filters.js
@@ -8,15 +8,18 @@ var runFilter = require('./run-filter');
 
 module.exports = handleFilters;
 function handleFilters(ast, filters, options) {
-  options = options || {}
+  options = options || {};
   walk(ast, function (node) {
     var dir = node.filename ? dirname(node.filename) : null;
     if (node.type === 'Filter') {
       handleNestedFilters(node, filters);
       var text = getBodyAsText(node);
       var attrs = getAttributes(node);
-      Object.keys(options).forEach(function (opt) {
-        attrs[opt] = attrs[opt] || options[opt];
+      var opts = options[node.name] || {};
+      Object.keys(opts).forEach(function (opt) {
+        if (!attrs.hasOwnProperty(opt)) {
+          attrs[opt] = opts[opt];
+        }
       });
       attrs.filename = node.filename;
       node.type = 'Text';

--- a/lib/handle-filters.js
+++ b/lib/handle-filters.js
@@ -15,9 +15,9 @@ function handleFilters(ast, filters, options) {
       handleNestedFilters(node, filters);
       var text = getBodyAsText(node);
       var attrs = getAttributes(node);
-      for (var opt in options) {
+      Object.keys(options).forEach(function (opt) {
         attrs[opt] = attrs[opt] || options[opt];
-      }
+      });
       attrs.filename = node.filename;
       node.type = 'Text';
       node.val = filterWithFallback(node, text, attrs);


### PR DESCRIPTION
Implements #13.

Options can now be passed as third parameter to `pug-filters`, to make it easy to preconfigure the filter with functions. To work with jade/pug core, this requires some additions. 

`options.filterOptions` needs to be passed at [lib/index.js#L83](https://github.com/pugjs/jade/blob/master/lib/index.js#L83), and `filterOptions: options.filterOptions` needs to be specified here: [lib/index.js#L175](https://github.com/pugjs/jade/blob/master/lib/index.js#L175).

I haven't submitted a PR to jade/pug core in case that I overlooked something in `pug-filters`.

For completeness, I have tested the code with the following, and had no issues. I neglected to write a formal test, so hopefully this snippet will suffice.

``` js
jade.compileFile('test.jade', {
  filterOptions: {
    'marked': {
      highlight: function (code) {
        return require('highlight.js').highlightAuto(code).value
      }
    }
  }
}
```
