### PR TITLE
Fix for include filters to return the string instead of the filename

### DIFF
--- a/lib/handle-filters.js
+++ b/lib/handle-filters.js
@@ -28,8 +28,9 @@ function handleFilters(ast, filters, options) {
       var firstFilter = node.filters.shift();
       var attrs = getAttributes(firstFilter);
       var filename = attrs.filename = node.file.fullPath;
+      var str = node.file.str;
       node.type = 'Text';
-      node.val = filterWithFallback(firstFilter, filename, attrs, 'renderFile');
+      node.val = filterWithFallback(firstFilter, str, attrs, 'renderFile');
       node.filters.forEach(function (filter) {
         var attrs = getAttributes(filter);
         attrs.filename = filename;


### PR DESCRIPTION
Solution to https://github.com/pugjs/pug/issues/2440
