### PR TITLE
Bugfix: The specified per-filter options were not applied to nested filters (version bumped to 1.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 1.2.5 / 2016-09-24
+
+- Bugfix: The specified per-filter options were not applied to nested filters
+
 ## 1.2.4 / 2016-08-23
 
 - Update to `pug-walk@1.0.0`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pug-filters",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Code for processing filters in pug templates",
   "keywords": [
     "pug"


### PR DESCRIPTION
This is a simple bug fix.

``` pug
script
  :cdata-js:babel(presets=['es2015'])
    const myFunc = () => `This is ES2015 in a CD${'ATA'}`;
```

When nested filters are used, the inner filter (babel) was failing to obtain its options from the `options.filterOptions.babel` table.
